### PR TITLE
Add support for Rocky, Alma, and Fedora

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -51,6 +51,27 @@
       ]
     },
     {
+      "operatingsystem": "Rocky",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "AlmaLinux",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
+      "operatingsystem": "Fedora",
+      "operatingsystemrelease": [
+        "36",
+        "37"
+      ]
+    },
+    {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "7",


### PR DESCRIPTION
* Bumped `herculesteam/augeasproviders_core` to < 4.0.0
* Bumped puppet version to < 8.0.0
* Updated OS support to latest known releases
* Added support for Rocky, Alma, and Fedora
